### PR TITLE
Updates for 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-transformers": "^1.0.0",
-    "purescript-refs": "^1.0.0"
+    "purescript-transformers": "^2.0.0",
+    "purescript-refs": "^2.0.0",
+    "purescript-functors": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-functions": "^1.0.0"
+    "purescript-console": "^2.0.0",
+    "purescript-functions": "^2.0.0"
   }
 }

--- a/src/Control/Parallel.purs
+++ b/src/Control/Parallel.purs
@@ -1,0 +1,30 @@
+module Control.Parallel
+  ( parTraverse
+  , parTraverse_
+  , module Control.Parallel.Class
+  ) where
+
+import Prelude
+
+import Control.Parallel.Class (class Parallel, parallel, sequential, ParCont(..))
+
+import Data.Foldable (class Foldable, traverse_)
+import Data.Traversable (class Traversable, traverse)
+
+-- | Traverse a collection in parallel.
+parTraverse
+  :: forall f m t a b
+   . (Parallel f m, Traversable t)
+  => (a -> m b)
+  -> t a
+  -> m (t b)
+parTraverse f = sequential <<< traverse (parallel <<< f)
+
+-- | Traverse a collection in parallel, discarding any results.
+parTraverse_
+  :: forall f m t a b
+   . (Parallel f m, Foldable t)
+  => (a -> m b)
+  -> t a
+  -> m Unit
+parTraverse_ f = sequential <<< traverse_ (parallel <<< f)

--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -1,188 +1,141 @@
 module Control.Parallel.Class
   ( class MonadPar
-  , par
   , parTraverse_
   , parTraverse
-  , class MonadRace
-  , stall
-  , race
   , Parallel
   , parallel
-  , runParallel
+  , sequential
   ) where
 
 import Prelude
-
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
-import Control.Apply (lift2)
 import Control.Monad.Cont.Trans (ContT(..), runContT)
 import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Ref (REF, writeRef, readRef, newRef)
 import Control.Monad.Eff.Unsafe (unsafeInterleaveEff)
-import Control.Monad.Except.Trans (ExceptT(..))
-import Control.Monad.Reader.Trans (ReaderT(..))
-import Control.Monad.Maybe.Trans (MaybeT(..))
-import Control.Monad.Writer.Trans (WriterT(..))
+import Control.Monad.Except (mapExceptT)
+import Control.Monad.Except.Trans (ExceptT)
+import Control.Monad.Reader.Trans (mapReaderT, ReaderT)
+import Control.Monad.Writer.Trans (mapWriterT, WriterT)
 import Control.Plus (class Plus)
-
 import Data.Foldable (class Foldable, traverse_)
 import Data.Maybe (Maybe(..))
 import Data.Monoid (class Monoid)
 import Data.Traversable (class Traversable, traverse)
-import Data.Tuple (Tuple(..))
 
--- | The `MonadPar` class abstracts over monads which support some notion of
--- | parallel composition.
--- |
--- | The `unit` and `par` functions should correspond to `pure` and `lift2` for
--- | some valid `Applicative` instance, but that instance need not arise from
--- | the underlying `Monad`.
-class Monad m <= MonadPar m where
-  par :: forall a b c. (a -> b -> c) -> m a -> m b -> m c
-
-instance monadParContT :: MonadPar (ContT Unit (Eff eff)) where
-  par f ca cb = ContT \k -> do
-    ra <- unsafeWithRef (newRef Nothing)
-    rb <- unsafeWithRef (newRef Nothing)
-
-    runContT ca \a -> do
-      mb <- unsafeWithRef (readRef rb)
-      case mb of
-        Nothing -> unsafeWithRef (writeRef ra (Just a))
-        Just b -> k (f a b)
-
-    runContT cb \b -> do
-      ma <- unsafeWithRef (readRef ra)
-      case ma of
-        Nothing -> unsafeWithRef (writeRef rb (Just b))
-        Just a -> k (f a b)
-
-instance monadParExceptT :: MonadPar m => MonadPar (ExceptT e m) where
-  par f (ExceptT e1) (ExceptT e2) = ExceptT (par (lift2 f) e1 e2)
-
-instance monadParMaybeT :: MonadPar m => MonadPar (MaybeT m) where
-  par f (MaybeT m1) (MaybeT m2) = MaybeT (par (lift2 f) m1 m2)
-
-instance monadParReaderT :: MonadPar m => MonadPar (ReaderT e m) where
-  par f (ReaderT r1) (ReaderT r2) = ReaderT \r -> par f (r1 r) (r2 r)
-
-instance monadParWriterT :: (Monoid w, MonadPar m) => MonadPar (WriterT w m) where
-  par f (WriterT w1) (WriterT w2) =
-    WriterT $
-      par (\(Tuple a wa) (Tuple b wb) → Tuple (f a b) (wa <> wb)) w1 w2
+-- | The `MonadPar` class abstracts over monads which support
+-- | parallel composition via some related `Applicative`.
+class (Monad m, Applicative f) <= MonadPar f m | m -> f, f -> m where
+  parallel   :: m ~> f
+  sequential :: f ~> m
 
 -- | Traverse a collection in parallel, discarding any results.
 parTraverse_
-  :: forall m t a b
-   . (MonadPar m, Foldable t)
+  :: forall f m t a b
+   . (MonadPar f m, Foldable t)
   => (a -> m b)
   -> t a
   -> m Unit
-parTraverse_ f = runParallel <<< traverse_ (Parallel <<< f)
+parTraverse_ f = sequential <<< traverse_ (parallel <<< f)
 
 -- | Traverse a collection in parallel.
 parTraverse
-  :: forall m t a b
-   . (MonadPar m, Traversable t)
+  :: forall f m t a b
+   . (MonadPar f m, Traversable t)
   => (a -> m b)
   -> t a
   -> m (t b)
-parTraverse f = runParallel <<< traverse (Parallel <<< f)
+parTraverse f = sequential <<< traverse (parallel <<< f)
 
--- | The `MonadRace` class extends `MonadPar` to those monads which can be
--- | _raced_. That is, monads for which two computations can be
--- |
--- | The `stall` and `race` functions should satisfy the `Alternative` laws.
-class MonadPar m <= MonadRace m where
-  stall :: forall a. m a
-  race :: forall a. m a -> m a -> m a
-
-unsafeWithRef :: forall eff a. Eff (ref :: REF | eff) a -> Eff eff a
-unsafeWithRef = unsafeInterleaveEff
-
-instance monadRaceContT :: MonadRace (ContT Unit (Eff eff)) where
-  stall = ContT \_ -> pure unit
-  race c1 c2 = ContT \k -> do
-    done <- unsafeWithRef (newRef false)
-
-    runContT c1 \a -> do
-      b <- unsafeWithRef (readRef done)
-      if b
-        then pure unit
-        else do
-          unsafeWithRef (writeRef done true)
-          k a
-
-    runContT c2 \a -> do
-      b <- unsafeWithRef (readRef done)
-      if b
-        then pure unit
-        else do
-          unsafeWithRef (writeRef done true)
-          k a
-
-instance monadRaceExceptT :: MonadRace m => MonadRace (ExceptT e m) where
-  stall = ExceptT stall
-  race (ExceptT e1) (ExceptT e2) = ExceptT (race e1 e2)
-
-instance monadRaceMaybeT :: MonadRace m => MonadRace (MaybeT m) where
-  stall = MaybeT stall
-  race (MaybeT m1) (MaybeT m2) = MaybeT (race m1 m2)
-
-instance monadRaceReaderT :: MonadRace m => MonadRace (ReaderT e m) where
-  stall = ReaderT \_ -> stall
-  race (ReaderT r1) (ReaderT r2) = ReaderT \r -> race (r1 r) (r2 r)
-
-instance monadRaceWriterT :: (Monoid w, MonadRace m) => MonadRace (WriterT w m) where
-  stall = WriterT stall
-  race (WriterT w1) (WriterT w2) = WriterT (race w1 w2)
-
--- | The `Parallel` type constructor provides `Applicative` and `Alternative`
--- | instances for any type monad with `MonadPar` and `MonadRace` instances
--- | respectively.
--- |
--- | - The definition of `apply` from `Apply` runs two computations in parallel and applies
--- |   a function when both complete.
--- | - The definition of `alt` from the `Alt` type class runs two computations in parallel
--- |   and returns the result of the computation which completes first.
+-- | The `Parallel` type constructor provides an `Applicative` instance
+-- | based on `ContT Unit m`, which waits for multiple continuations to be
+-- | resumed simultaneously.
 -- |
 -- | Parallel sections of code can be embedded in sequential code by using
--- | the `parallel` and `runParallel` functions:
+-- | the `parallel` and `sequential` functions:
 -- |
 -- | ```purescript
 -- | loadModel :: ContT Unit (Eff (ajax :: AJAX)) Model
 -- | loadModel = do
 -- |   token <- authenticate
--- |   runParallel $
+-- |   sequential $
 -- |     Model <$> parallel (get "/products/popular/" token)
 -- |           <*> parallel (get "/categories/all" token)
 -- | ```
-newtype Parallel m a = Parallel (m a)
+newtype Parallel m a = Parallel (ContT Unit m a)
 
--- | Lift a computation to be run in parallel from a computation in the
--- | corresponding `Monad`.
-parallel :: forall m a. m a -> Parallel m a
-parallel = Parallel
+instance functorParallel :: MonadEff eff m => Functor (Parallel m) where
+  map f = parallel <<< map f <<< sequential
 
--- | Lower a parallel computation to the underlying `Monad`, so that it may be
--- | used in a larger sequential computation.
-runParallel :: forall m a. Parallel m a -> m a
-runParallel (Parallel ma) = ma
+instance applyParallel :: MonadEff eff m => Apply (Parallel m) where
+  apply (Parallel ca) (Parallel cb) = Parallel $ ContT \k -> do
+    ra <- liftEff $ unsafeWithRef (newRef Nothing)
+    rb <- liftEff $ unsafeWithRef (newRef Nothing)
 
-instance functorParallel :: Functor m => Functor (Parallel m) where
-  map f = parallel <<< map f <<< runParallel
+    runContT ca \a -> do
+      mb <- liftEff $ unsafeWithRef (readRef rb)
+      case mb of
+        Nothing -> liftEff $ unsafeWithRef (writeRef ra (Just a))
+        Just b -> k (a b)
 
-instance applyParallel :: MonadPar m => Apply (Parallel m) where
-  apply f a = parallel (par ($) (runParallel f) (runParallel a))
+    runContT cb \b -> do
+      ma <- liftEff $ unsafeWithRef (readRef ra)
+      case ma of
+        Nothing -> liftEff $ unsafeWithRef (writeRef rb (Just b))
+        Just a -> k (a b)
 
-instance applicativeParallel :: MonadPar m => Applicative (Parallel m) where
+instance applicativeParallel :: MonadEff eff m => Applicative (Parallel m) where
   pure = parallel <<< pure
 
-instance altParallel :: MonadRace m => Alt (Parallel m) where
-  alt a b = parallel (runParallel a `race` runParallel b)
+instance altParallel :: MonadEff eff m => Alt (Parallel m) where
+  alt (Parallel c1) (Parallel c2) = Parallel $ ContT \k -> do
+    done <- liftEff $ unsafeWithRef (newRef false)
 
-instance plusParallel :: MonadRace m => Plus (Parallel m) where
-  empty = parallel stall
+    runContT c1 \a -> do
+      b <- liftEff $ unsafeWithRef (readRef done)
+      if b
+        then pure unit
+        else do
+          liftEff $ unsafeWithRef (writeRef done true)
+          k a
 
-instance alternativeParallel :: MonadRace m => Alternative (Parallel m)
+    runContT c2 \a -> do
+      b <- liftEff $ unsafeWithRef (readRef done)
+      if b
+        then pure unit
+        else do
+          liftEff $ unsafeWithRef (writeRef done true)
+          k a
+
+instance plusParallel :: MonadEff eff m => Plus (Parallel m) where
+  empty = Parallel $ ContT \_ -> pure unit
+
+instance alternativeParallel :: MonadEff eff m => Alternative (Parallel m)
+
+instance monadParParallel :: MonadEff eff m => MonadPar (Parallel m) (ContT Unit m) where
+  parallel = Parallel
+  sequential (Parallel ma) = ma
+
+instance monadParExceptT :: MonadPar f m => MonadPar (ExceptT e f) (ExceptT e m) where
+  parallel = mapExceptT parallel
+  sequential = mapExceptT sequential
+
+instance monadParReaderT :: MonadPar f m => MonadPar (ReaderT e f) (ReaderT e m) where
+  parallel = mapReaderT parallel
+  sequential = mapReaderT sequential
+
+instance monadParWriterT :: (Monoid w, MonadPar f m) => MonadPar (WriterT w f) (WriterT w m) where
+  parallel = mapWriterT parallel
+  sequential = mapWriterT sequential
+
+-- This instance doesn't work yet, since the Applicative instance for MaybeT is
+-- too restrictive.
+
+-- instance monadParMaybeT :: MonadPar f m => MonadPar (MaybeT f) (MaybeT m) where
+--   parallel = mapMaybeT ?p
+--   sequential = mapMaybeT ?s
+
+unsafeWithRef :: forall eff a. Eff (ref :: REF | eff) a -> Eff eff a
+unsafeWithRef = unsafeInterleaveEff

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,7 @@ import Prelude (Unit, (<<<))
 import Control.Monad.Cont.Trans (ContT(..), runContT)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, logShow)
-import Control.Parallel.Class (parTraverse)
+import Control.Parallel (parTraverse)
 
 newtype Request = Request
   { host :: String


### PR DESCRIPTION
cc @garyb @natefaubion

Another big change ... this one expresses things quite naturally though, I think. A `Monad` is a `MonadPar` if it can be paired with a corresponding `Applicative` with some notion of parallel composition.

Note that

- `Parallel` has been generalized to work with any `MonadEff` under `ContT` (this needs a functional dependency on `MonadEff`)
- The functional dependency is bidirectional, which is slightly unfortunate, but necessary for some things to type-check nicely.
- the tests still pass without any changes 😃 