### PR TITLE
Update description of MonadRace

### DIFF
--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -91,7 +91,8 @@ parTraverse
 parTraverse f = runParallel <<< traverse (Parallel <<< f)
 
 -- | The `MonadRace` class extends `MonadPar` to those monads which can be
--- | _raced_. That is, monads for which two computations can be
+-- | _raced_. That is, monads for which two computations can be executed in parallel
+-- | returning the result from the computation which finishes first.
 -- |
 -- | The `stall` and `race` functions should satisfy the `Alternative` laws.
 class MonadPar m <= MonadRace m where


### PR DESCRIPTION
description of `MonadRec` is not as descriptive as [old description](https://github.com/purescript/purescript-parallel/commit/b5594205ffa4f73bfa66688910d80fedcb4acfc0) of `race` was

> Run two asynchronous computations in parallel, returning the result
> from the computation which finishes first.

