### PR TITLE
Add parallel apply

### DIFF
--- a/src/Control/Parallel.purs
+++ b/src/Control/Parallel.purs
@@ -5,6 +5,8 @@ module Control.Parallel
   , parSequence_
   , parOneOf
   , parOneOfMap
+  , parApply
+  , (<!>)
   , module Control.Parallel.Class
   ) where
 
@@ -15,6 +17,16 @@ import Control.Parallel.Class (class Parallel, parallel, sequential, ParCont(..)
 
 import Data.Foldable (class Foldable, traverse_, oneOfMap)
 import Data.Traversable (class Traversable, traverse)
+
+parApply
+  :: forall f m a b
+   . Parallel f m
+   => m (a -> b)
+   -> m a
+   -> m b
+parApply mf ma = apply (parallel mf) (parallel ma) # sequential
+
+infixl 4 apply as <!>
 
 -- | Traverse a collection in parallel.
 parTraverse

--- a/src/Control/Parallel.purs
+++ b/src/Control/Parallel.purs
@@ -18,13 +18,14 @@ import Control.Parallel.Class (class Parallel, parallel, sequential, ParCont(..)
 import Data.Foldable (class Foldable, traverse_, oneOfMap)
 import Data.Traversable (class Traversable, traverse)
 
+-- | Apply a function to an arguement under a type constructor in parallel.
 parApply
   :: forall f m a b
    . Parallel f m
    => m (a -> b)
    -> m a
    -> m b
-parApply mf ma = apply (parallel mf) (parallel ma) # sequential
+parApply mf ma = sequential(apply (parallel mf) (parallel ma))
 
 infixl 4 apply as <!>
 

--- a/src/Control/Parallel.purs
+++ b/src/Control/Parallel.purs
@@ -6,7 +6,6 @@ module Control.Parallel
   , parOneOf
   , parOneOfMap
   , parApply
-  , (<!>)
   , module Control.Parallel.Class
   ) where
 
@@ -27,7 +26,6 @@ parApply
    -> m b
 parApply mf ma = sequential(apply (parallel mf) (parallel ma))
 
-infixl 4 apply as <!>
 
 -- | Traverse a collection in parallel.
 parTraverse


### PR DESCRIPTION
Adds a new function and operator (open for bike shedding on a more fitting operator) for parallel application. Would allow us to write:

```
Tuple <$> (Ajax.get "https://foo.com") <!> (Ajax.get "https://bar.com")
```

instead of:

```
sequential $
    Tuple <$> parallel (Ajax.get "https://foo.com")
          <*> parallel (Ajax.get "https://bar.com")
```