### PR TITLE
add instance for Star

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "purescript-maybe": "^4.0.0",
     "purescript-newtype": "^3.0.0",
     "purescript-prelude": "^4.0.0",
+    "purescript-profunctor": "^4.0.0",
     "purescript-refs": "^4.0.0",
     "purescript-transformers": "^4.0.0"
   },

--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -14,6 +14,7 @@ import Data.Either (Either)
 import Data.Functor.Compose (Compose(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.Profunctor.Star (Star(..))
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Ref as Ref
 
@@ -38,6 +39,10 @@ instance monadParWriterT :: (Monoid w, Parallel f m) => Parallel (WriterT w f) (
 instance monadParMaybeT :: Parallel f m => Parallel (Compose f Maybe) (MaybeT m) where
   parallel (MaybeT ma) = Compose (parallel ma)
   sequential (Compose fa) = MaybeT (sequential fa)
+
+instance monadParStar :: Parallel f m => Parallel (Star f a) (Star m a) where
+  parallel (Star f) = (Star $ parallel <<< f)
+  sequential (Star f) = (Star $ sequential <<< f)
 
 -- | The `ParCont` type constructor provides an `Applicative` instance
 -- | based on `ContT Unit m`, which waits for multiple continuations to be

--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -14,6 +14,7 @@ import Data.Either (Either)
 import Data.Functor.Compose (Compose(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.Profunctor.Costar (Costar(..))
 import Data.Profunctor.Star (Star(..))
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Ref as Ref
@@ -43,6 +44,11 @@ instance monadParMaybeT :: Parallel f m => Parallel (Compose f Maybe) (MaybeT m)
 instance monadParStar :: Parallel f m => Parallel (Star f a) (Star m a) where
   parallel (Star f) = (Star $ parallel <<< f)
   sequential (Star f) = (Star $ sequential <<< f)
+
+instance monadParCostar :: Parallel f m => Parallel (Costar f a) (Costar m a) where
+  parallel (Costar f) = (Costar $ sequential >>> f)
+  sequential (Costar f) = (Costar $ parallel >>> f)
+
 
 -- | The `ParCont` type constructor provides an `Applicative` instance
 -- | based on `ContT Unit m`, which waits for multiple continuations to be


### PR DESCRIPTION
To define this instance either `purescript-profunctor` should be added here or `purescript-parallel` should be added to `purescript-profunctor`.

this option is much better as from all `purescript-profunctor` dependencies only `purescript-invariant` is not in dependencies of `purescript-parallel`. `purescript-invariant` itself has dependency only on prelude. so this change basically results in adding of `purescript-profunctor` `purescript-invariant` modules

<details>
  <summary>dependencies of purescript-paralle</summary>
 ├─┬ purescript-parallel#4.0.0
│ ├─┬ purescript-control#4.1.0
│ │ └── purescript-prelude#4.1.0
│ ├─┬ purescript-effect#2.0.1
│ │ └── purescript-prelude#4.1.0
│ ├─┬ purescript-either#4.1.1
│ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-control#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-invariant#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-maybe#4.0.1
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ └── purescript-prelude#4.1.0
│ ├─┬ purescript-foldable-traversable#4.1.1
│ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-control#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-maybe#4.0.1
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-newtype#3.0.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-orders#4.0.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ └── purescript-prelude#4.1.0
│ ├─┬ purescript-functors#3.1.1
│ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-const#4.1.0
│ │ │ ├─┬ purescript-contravariant#4.0.0
│ │ │ │ ├─┬ purescript-either#4.1.1
│ │ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├── purescript-prelude#4.1.0
│ │ │ │ └─┬ purescript-tuples#5.1.0
│ │ │ │   ├─┬ purescript-bifunctors#4.0.0
│ │ │ │   │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-control#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-distributive#4.0.0
│ │ │ │   │ ├─┬ purescript-identity#4.1.0
│ │ │ │   │ │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │   │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │   │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │   │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │   │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │   │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-maybe#4.0.1
│ │ │ │   │ │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-orders#4.0.0
│ │ │ │   │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-invariant#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-maybe#4.0.1
│ │ │ │   │ ├─┬ purescript-control#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-invariant#4.1.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ │ └── purescript-prelude#4.1.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├─┬ purescript-newtype#3.0.0
│ │ │ │   │ └── purescript-prelude#4.1.0
│ │ │ │   ├── purescript-prelude#4.1.0
│ │ │ │   └── purescript-type-equality#3.0.0
│ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-control#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-either#4.1.1
│ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-maybe#4.0.1
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-newtype#3.0.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├── purescript-prelude#4.1.0
│ │ ├─┬ purescript-tuples#5.1.0
│ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-distributive#4.0.0
│ │ │ │ ├─┬ purescript-identity#4.1.0
│ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-orders#4.0.0
│ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-maybe#4.0.1
│ │ │ │ ├─┬ purescript-control#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-invariant#4.1.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ │ └── purescript-prelude#4.1.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├─┬ purescript-newtype#3.0.0
│ │ │ │ └── purescript-prelude#4.1.0
│ │ │ ├── purescript-prelude#4.1.0
│ │ │ └── purescript-type-equality#3.0.0
│ │ └── purescript-unsafe-coerce#4.0.0
│ ├─┬ purescript-maybe#4.0.1
│ │ ├─┬ purescript-control#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-invariant#4.1.0
│ │ │ └── purescript-prelude#4.1.0
│ │ ├─┬ purescript-newtype#3.0.0
│ │ │ └── purescript-prelude#4.1.0
│ │ └── purescript-prelude#4.1.0
│ ├─┬ purescript-newtype#3.0.0
│ │ └── purescript-prelude#4.1.0
│ ├── purescript-prelude#4.1.0
│ ├─┬ purescript-refs#4.1.0
│ │ ├─┬ purescript-effect#2.0.1
│ │ │ └── purescript-prelude#4.1.0
│ │ └── purescript-prelude#4.1.0
│ └─┬ purescript-transformers#4.2.0
│   ├─┬ purescript-control#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-distributive#4.0.0
│   │ ├─┬ purescript-identity#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-newtype#3.0.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-effect#2.0.1
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-either#4.1.1
│   │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-invariant#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-maybe#4.0.1
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-exceptions#4.0.0
│   │ ├─┬ purescript-effect#2.0.1
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-either#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-maybe#4.0.1
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-foldable-traversable#4.1.1
│   │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-maybe#4.0.1
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-newtype#3.0.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-orders#4.0.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-identity#4.1.0
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-invariant#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-newtype#3.0.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-lazy#4.0.0
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-invariant#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-maybe#4.0.1
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-invariant#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-newtype#3.0.0
│   │ │ └── purescript-prelude#4.1.0
│   │ └── purescript-prelude#4.1.0
│   ├─┬ purescript-newtype#3.0.0
│   │ └── purescript-prelude#4.1.0
│   ├── purescript-prelude#4.1.0
│   ├─┬ purescript-tailrec#4.0.0
│   │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-effect#2.0.1
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-either#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-identity#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-maybe#4.0.1
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├── purescript-partial#2.0.1
│   │ ├── purescript-prelude#4.1.0
│   │ └── purescript-refs#4.1.0
│   ├─┬ purescript-tuples#5.1.0
│   │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-control#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-distributive#4.0.0
│   │ │ ├─┬ purescript-identity#4.1.0
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-foldable-traversable#4.1.1
│   │ │ ├─┬ purescript-bifunctors#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-maybe#4.0.1
│   │ │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-orders#4.0.0
│   │ │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ │ └── purescript-prelude#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-invariant#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-maybe#4.0.1
│   │ │ ├─┬ purescript-control#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-invariant#4.1.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ ├─┬ purescript-newtype#3.0.0
│   │ │ │ └── purescript-prelude#4.1.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├─┬ purescript-newtype#3.0.0
│   │ │ └── purescript-prelude#4.1.0
│   │ ├── purescript-prelude#4.1.0
│   │ └── purescript-type-equality#3.0.0
│   └─┬ purescript-unfoldable#4.0.0
│     ├─┬ purescript-foldable-traversable#4.1.1
│     │ ├─┬ purescript-bifunctors#4.0.0
│     │ │ ├─┬ purescript-newtype#3.0.0
│     │ │ │ └── purescript-prelude#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-control#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-maybe#4.0.1
│     │ │ ├─┬ purescript-control#4.1.0
│     │ │ │ └── purescript-prelude#4.1.0
│     │ │ ├─┬ purescript-invariant#4.1.0
│     │ │ │ └── purescript-prelude#4.1.0
│     │ │ ├─┬ purescript-newtype#3.0.0
│     │ │ │ └── purescript-prelude#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-newtype#3.0.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-orders#4.0.0
│     │ │ ├─┬ purescript-newtype#3.0.0
│     │ │ │ └── purescript-prelude#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ └── purescript-prelude#4.1.0
│     ├─┬ purescript-maybe#4.0.1
│     │ ├─┬ purescript-control#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-invariant#4.1.0
│     │ │ └── purescript-prelude#4.1.0
│     │ ├─┬ purescript-newtype#3.0.0
│     │ │ └── purescript-prelude#4.1.0
│     │ └── purescript-prelude#4.1.0
│     ├── purescript-partial#2.0.1
│     ├── purescript-prelude#4.1.0
│     └─┬ purescript-tuples#5.1.0
│       ├─┬ purescript-bifunctors#4.0.0
│       │ ├─┬ purescript-newtype#3.0.0
│       │ │ └── purescript-prelude#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-control#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-distributive#4.0.0
│       │ ├─┬ purescript-identity#4.1.0
│       │ │ ├─┬ purescript-control#4.1.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ ├─┬ purescript-foldable-traversable#4.1.1
│       │ │ │ ├─┬ purescript-bifunctors#4.0.0
│       │ │ │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ ├─┬ purescript-control#4.1.0
│       │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ ├─┬ purescript-maybe#4.0.1
│       │ │ │ │ ├─┬ purescript-control#4.1.0
│       │ │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ │ ├─┬ purescript-invariant#4.1.0
│       │ │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ ├─┬ purescript-orders#4.0.0
│       │ │ │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ │ └── purescript-prelude#4.1.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ ├─┬ purescript-invariant#4.1.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-newtype#3.0.0
│       │ │ └── purescript-prelude#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-foldable-traversable#4.1.1
│       │ ├─┬ purescript-bifunctors#4.0.0
│       │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-control#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-maybe#4.0.1
│       │ │ ├─┬ purescript-control#4.1.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ ├─┬ purescript-invariant#4.1.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-newtype#3.0.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-orders#4.0.0
│       │ │ ├─┬ purescript-newtype#3.0.0
│       │ │ │ └── purescript-prelude#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-invariant#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-maybe#4.0.1
│       │ ├─┬ purescript-control#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-invariant#4.1.0
│       │ │ └── purescript-prelude#4.1.0
│       │ ├─┬ purescript-newtype#3.0.0
│       │ │ └── purescript-prelude#4.1.0
│       │ └── purescript-prelude#4.1.0
│       ├─┬ purescript-newtype#3.0.0
│       │ └── purescript-prelude#4.1.0
│       ├── purescript-prelude#4.1.0
│       └── purescript-type-equality#3.0.0

</details>
<details>
  <summary>direct dependencies of purescript-profunctor</summary>
    "purescript-contravariant": "^4.0.0",
    "purescript-control": "^4.0.0",
    "purescript-distributive": "^4.0.0",
    "purescript-either": "^4.0.0",
    "purescript-exists": "^4.0.0",
    "purescript-invariant": "^4.0.0",
    "purescript-newtype": "^3.0.0",
    "purescript-prelude": "^4.0.0",
    "purescript-tuples": "^5.0.0"
</details>
