### PR TITLE
Remove `Monad` and `Applicative` constraints on the `Parallel` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Remove `Monad` and `Applicative` constraints on the `Parallel` class. Both
+types now only require `Apply`. (#43 by @artemisSystem)
 
 New features:
 

--- a/src/Control/Parallel.purs
+++ b/src/Control/Parallel.purs
@@ -30,6 +30,7 @@ parApply mf ma = sequential(apply (parallel mf) (parallel ma))
 parTraverse
   :: forall f m t a b
    . Parallel f m
+  => Applicative f
   => Traversable t
   => (a -> m b)
   -> t a
@@ -40,6 +41,7 @@ parTraverse f = sequential <<< traverse (parallel <<< f)
 parTraverse_
   :: forall f m t a b
    . Parallel f m
+  => Applicative f
   => Foldable t
   => (a -> m b)
   -> t a
@@ -49,6 +51,7 @@ parTraverse_ f = sequential <<< traverse_ (parallel <<< f)
 parSequence
   :: forall a t m f
    . Parallel f m
+  => Applicative f
   => Traversable t
   => t (m a)
   -> m (t a)
@@ -57,6 +60,7 @@ parSequence = parTraverse identity
 parSequence_
   :: forall a t m f
    . Parallel f m
+  => Applicative f
   => Foldable t
   => t (m a)
   -> m Unit

--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -27,7 +27,7 @@ class (Apply m, Apply f) <= Parallel f m | m -> f, f -> m where
   parallel :: m ~> f
   sequential :: f ~> m
 
-instance monadParExceptT :: (Parallel f m, Apply (ExceptT e m)) => Parallel (Compose f (Either e)) (ExceptT e m) where
+instance monadParExceptT :: (Parallel f m, Monad m) => Parallel (Compose f (Either e)) (ExceptT e m) where
   parallel (ExceptT ma) = Compose (parallel ma)
   sequential (Compose fa) = ExceptT (sequential fa)
 
@@ -39,7 +39,7 @@ instance monadParWriterT :: (Monoid w, Parallel f m) => Parallel (WriterT w f) (
   parallel = mapWriterT parallel
   sequential = mapWriterT sequential
 
-instance monadParMaybeT :: (Parallel f m, Apply (MaybeT m)) => Parallel (Compose f Maybe) (MaybeT m) where
+instance monadParMaybeT :: (Parallel f m, Monad m) => Parallel (Compose f Maybe) (MaybeT m) where
   parallel (MaybeT ma) = Compose (parallel ma)
   sequential (Compose fa) = MaybeT (sequential fa)
 

--- a/src/Control/Parallel/Class.purs
+++ b/src/Control/Parallel/Class.purs
@@ -19,13 +19,15 @@ import Data.Profunctor.Star (Star(..))
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Ref as Ref
 
--- | The `Parallel` class abstracts over monads which support
--- | parallel composition via some related `Applicative`.
-class (Monad m, Applicative f) <= Parallel f m | m -> f, f -> m where
+-- | The `Parallel` class abstracts over pairs of `Apply`s where one of them
+-- | (`m`) composes sequentially, and the other (`f`) composes in parallel.
+-- | `m` is usually a `Monad`, which enforces the sequential nature of its
+-- | composition, but it doesn't need to be.
+class (Apply m, Apply f) <= Parallel f m | m -> f, f -> m where
   parallel :: m ~> f
   sequential :: f ~> m
 
-instance monadParExceptT :: Parallel f m => Parallel (Compose f (Either e)) (ExceptT e m) where
+instance monadParExceptT :: (Parallel f m, Apply (ExceptT e m)) => Parallel (Compose f (Either e)) (ExceptT e m) where
   parallel (ExceptT ma) = Compose (parallel ma)
   sequential (Compose fa) = ExceptT (sequential fa)
 
@@ -37,7 +39,7 @@ instance monadParWriterT :: (Monoid w, Parallel f m) => Parallel (WriterT w f) (
   parallel = mapWriterT parallel
   sequential = mapWriterT sequential
 
-instance monadParMaybeT :: Parallel f m => Parallel (Compose f Maybe) (MaybeT m) where
+instance monadParMaybeT :: (Parallel f m, Apply (MaybeT m)) => Parallel (Compose f Maybe) (MaybeT m) where
   parallel (MaybeT ma) = Compose (parallel ma)
   sequential (Compose fa) = MaybeT (sequential fa)
 
@@ -48,7 +50,6 @@ instance monadParStar :: Parallel f m => Parallel (Star f a) (Star m a) where
 instance monadParCostar :: Parallel f m => Parallel (Costar f a) (Costar m a) where
   parallel (Costar f) = (Costar $ sequential >>> f)
   sequential (Costar f) = (Costar $ parallel >>> f)
-
 
 -- | The `ParCont` type constructor provides an `Applicative` instance
 -- | based on `ContT Unit m`, which waits for multiple continuations to be


### PR DESCRIPTION
**Description of the change**

Both types now only require `Apply`. This is to allow more types to have a `Parallel` instance.

Closes #24 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [N/A] Added a test for the contribution (if applicable)
